### PR TITLE
Start autodismiss only when view has been animated.

### DIFF
--- a/IIShortNotificationPresenter/IIShortNotificationPresenter.m
+++ b/IIShortNotificationPresenter/IIShortNotificationPresenter.m
@@ -274,12 +274,11 @@ static inline BOOL IsEmpty(id thing) {
         _topConstraint.constant = 0;
         [_overlayView layoutIfNeeded];
     } completion:^(BOOL finished) {
-        [NSObject cancelPreviousPerformRequestsWithTarget:self];
         if (type != IIShortNotificationError) {
             [self performSelector:@selector(autoDismiss) withObject:nil afterDelay:self.autoDismissDelay];
         }
     }];
-
+    [NSObject cancelPreviousPerformRequestsWithTarget:self];
     
 }
 

--- a/IIShortNotificationPresenter/IIShortNotificationPresenter.m
+++ b/IIShortNotificationPresenter/IIShortNotificationPresenter.m
@@ -274,12 +274,13 @@ static inline BOOL IsEmpty(id thing) {
         _topConstraint.constant = 0;
         [_overlayView layoutIfNeeded];
     } completion:^(BOOL finished) {
+        [NSObject cancelPreviousPerformRequestsWithTarget:self];
+        if (type != IIShortNotificationError) {
+            [self performSelector:@selector(autoDismiss) withObject:nil afterDelay:self.autoDismissDelay];
+        }
     }];
 
-    [NSObject cancelPreviousPerformRequestsWithTarget:self];
-    if (type != IIShortNotificationError) {
-        [self performSelector:@selector(autoDismiss) withObject:nil afterDelay:self.autoDismissDelay];
-    }
+    
 }
 
 - (void)autoDismiss {


### PR DESCRIPTION
This should fix the problem when the main thread does not immediately renders the notification
